### PR TITLE
fix typo in workshop type

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: workshop      # DON'T CHANGE THIS.
-carpentry: "sc"    # what kind of Carpentry (must be either "lc" or "dc" or "swc")
+carpentry: "swc"    # what kind of Carpentry (must be either "lc" or "dc" or "swc")
 venue: "Old Dominion University"        # brief name of host site without address (e.g., "Euphoric State University")
 address: "Old Dominion University, Perry Library Learning Commons, Conference Room 1310-1311"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
 country: "us"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1)


### PR DESCRIPTION
Workshop type for Software Carpentry is 'swc' not 'sc'